### PR TITLE
only display command list one time

### DIFF
--- a/commandline.h
+++ b/commandline.h
@@ -74,7 +74,6 @@ commandline_run(CommandLine *command, int argc, char **argv)
 	if (argc >= 2 && (streq(argv[1], "--help") || streq(argv[1], "-h")))
 	{
 		commandline_print_usage(command, stdout);
-		(void) commandline_print_command_tree(command, stdout);
 		return;
 	}
 


### PR DESCRIPTION
see https://github.com/openziti/ziti-tunnel-sdk-c/issues/462

https://github.com/dimitri/subcommands.c solved it by removing the top line, not the bottom line but that doesn't end up printing the usage